### PR TITLE
Fix for building Picha on m1 with brew dependencies

### DIFF
--- a/binding.gyp
+++ b/binding.gyp
@@ -53,9 +53,19 @@
 					'defines': [
 						'WITH_JPEG',
 					],
-					'libraries': [
-						'-ljpeg',
+					'cflags': [
+						'<!@(pkg-config libjpeg --cflags)',
 					],
+					'ldflags': [
+						'<!@(pkg-config libjpeg --libs-only-L --libs-only-other)',
+					],
+					'libraries': [
+						'<!@(pkg-config libjpeg --libs-only-l)',
+					],
+					'xcode_settings': {
+						'OTHER_CFLAGS': [ '<!@(pkg-config libjpeg --cflags)' ],
+						'OTHER_LDFLAGS': [ '<!@(pkg-config libjpeg --libs-only-L --libs-only-other)' ],
+					},
 				}],
 				['with_tiff == "yes"', {
 					'sources': [

--- a/binding.gyp
+++ b/binding.gyp
@@ -54,13 +54,13 @@
 						'WITH_JPEG',
 					],
 					'cflags': [
-						'<!@(pkg-config libjpeg --cflags)',
+						'<!@(pkg-config libjpeg --cflags --silence-errors)',
 					],
 					'ldflags': [
-						'<!@(pkg-config libjpeg --libs-only-L --libs-only-other)',
+						'<!@(pkg-config libjpeg --libs-only-L --libs-only-other --silence-errors)',
 					],
 					'libraries': [
-						'<!@(pkg-config libjpeg --libs-only-l)',
+						'-ljpeg <!@(pkg-config libjpeg --libs-only-l --silence-errors)',
 					],
 					'xcode_settings': {
 						'OTHER_CFLAGS': [ '<!@(pkg-config libjpeg --cflags)' ],


### PR DESCRIPTION
The build process was not finding `jpeglib.h` on my m1 when building picha. I suspect its because it could not figure out where the dependencies were stored because brew puts them in `/opt/homebrew` instead of something like `/opt/local`

These changes (similar to the other build config for other dependencies) allowed the build to complete.

**Testing**
1. `npm install --build-from-source` should complete without error